### PR TITLE
Added Excel (XSL and XLSX) rules

### DIFF
--- a/file/office.yar
+++ b/file/office.yar
@@ -1,5 +1,5 @@
 /*
-    Author: Jaume Martin
+    Author: Jaume Martin && Joan Bono
     Date: 24/04/2017
     Description: This finds the magics on individual files.
 */

--- a/file/office.yar
+++ b/file/office.yar
@@ -15,3 +15,64 @@ rule doc_magic: DOC
     condition:
        $a at 0
 }
+
+rule excel_2007_magic: XLSX
+{
+    meta:
+        author = "Joan Bono"
+
+    strings:
+        $a = { 50 4b 03 04 }
+
+    condition:
+       $a at 0
+}
+
+rule excel_2003_magic: XLS
+{
+    meta:
+        author = "Joan Bono"
+
+    strings:
+        $a = { D0 CF 11 E0 A1 B1 1A E1 00 }
+
+    condition:
+       $a at 0
+}
+
+rule excel_XML_magic: XLS
+{
+    meta:
+        author = "Joan Bono"
+
+    strings:
+        $a = { 3C 3F 78 6D 6C 20 76 }
+
+    condition:
+       $a at 0
+}
+
+rule excel_OS2worksheet_magic: XLS
+{
+    meta:
+        author = "Joan Bono"
+
+    strings:
+        $a = { 09 00 04 00 06 00 }
+
+    condition:
+       $a at 0
+}
+
+rule excel_OrthoTrack_magic: XLS
+{
+    meta:
+        author = "Joan Bono"
+
+    strings:
+        $a = { 56 65 72 73 69 6F 6E 09 }
+
+    condition:
+       $a at 0
+}
+

--- a/raw/office.yar
+++ b/raw/office.yar
@@ -1,5 +1,5 @@
 /*
-    Author: Jaume Martin
+    Author: Jaume Martin && Joan Bono
     Date: 26/04/2017
     Description: This finds the magics on dump files, like raw dd image. This can though false positives.
 */
@@ -15,3 +15,64 @@ rule contains_doc: DOC
     condition:
        $a
 }
+
+rule excel_2007_magic: XLSX
+{
+    meta:
+        author = "Joan Bono"
+
+    strings:
+        $a = { 50 4b 03 04 }
+
+    condition:
+       $a
+}
+
+rule excel_2003_magic: XLS
+{
+    meta:
+        author = "Joan Bono"
+
+    strings:
+        $a = { D0 CF 11 E0 A1 B1 1A E1 00 }
+
+    condition:
+       $a
+}
+
+rule excel_XML_magic: XLS
+{
+    meta:
+        author = "Joan Bono"
+
+    strings:
+        $a = { 3C 3F 78 6D 6C 20 76 }
+
+    condition:
+       $a
+}
+
+rule excel_OS2worksheet_magic: XLS
+{
+    meta:
+        author = "Joan Bono"
+
+    strings:
+        $a = { 09 00 04 00 06 00 }
+
+    condition:
+       $a
+}
+
+rule excel_OrthoTrack_magic: XLS
+{
+    meta:
+        author = "Joan Bono"
+
+    strings:
+        $a = { 56 65 72 73 69 6F 6E 09 }
+
+    condition:
+       $a
+}
+


### PR DESCRIPTION
Added Excel (XSLX and XLS) rules to `file/office.yar`  and `raw/office.yar` 

+ Excel 2007+ Magic: `50 4b 03 04`
+ Excel 2003- Magic: `D0 CF 11 E0 A1 B1 1A E1 00`
+ Excel XML Magic: `3C 3F 78 6D 6C 20 76`
+ Excel OS/2 Magic (v2.0 and v3.0): `09 00 04 00 06 00`
+ Excel OrthoTrack Magic: `56 65 72 73 69 6F 6E 09`